### PR TITLE
62 add a new endpoint to add shift data

### DIFF
--- a/api/api/openapi.yml
+++ b/api/api/openapi.yml
@@ -239,12 +239,24 @@ components:
             Shift:
               $ref: '#/components/schemas/Shift'
     importShiftData:
-      type: object
-      properties:
-        shift: {type: array, example: [
-          {date: "2024-05-01", logins: ["tkanda", "jkobayas", "kyamagis", "tatwatan", "yuohno", "mogawa", "sumurata"]}, 
-          {date: "2024-05-02", logins: ["snara", "mmakinou", "fwatanab", "kyamagis", "toshota", "kemizuki", "misuzuki"]}
-          ]}
+      type: array
+      items:
+        type: object
+        properties:
+          date:
+            type: string
+            format: date
+            example: "2024-05-01"
+          login:
+            type: array
+            items:
+              type: string
+            example: ["user1", "user2"]
+      example:
+        - date: "2024-05-01"
+          login: ["user1", "user2"]
+        - date: "2024-05-02"
+          login: ["user3", "user4"]
     addedDate:
       type: object
       properties:

--- a/api/api/openapi.yml
+++ b/api/api/openapi.yml
@@ -29,6 +29,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+    post:
+      summary: "シフトの追加"
+      description: "日付とそれに対応した複数loginをDBに反映する"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/importShiftData'
+              required:
+                - shift
+      responses:
+        '200':
+          description: "成功。追加した日付一覧をjsonで返します"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/addedDate'
+        '400':
+          description: "失敗。エラーメッセージをjsonで返します"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /users:
     post:
       summary: "ユーザの追加"
@@ -214,6 +238,17 @@ components:
         properties:
             Shift:
               $ref: '#/components/schemas/Shift'
+    importShiftData:
+      type: object
+      properties:
+        shift: {type: array, example: [
+          {date: "2024-05-01", logins: ["tkanda", "jkobayas", "kyamagis", "tatwatan", "yuohno", "mogawa", "sumurata"]}, 
+          {date: "2024-05-02", logins: ["snara", "mmakinou", "fwatanab", "kyamagis", "toshota", "kemizuki", "misuzuki"]}
+          ]}
+    addedDate:
+      type: object
+      properties:
+        date: {type: array, example: ["2024-05-01", "2024-05-02"]}
     ActivityData:
       type: object
       properties:

--- a/api/src/db.go
+++ b/api/src/db.go
@@ -347,12 +347,14 @@ func addShiftToDB(schedule []Schedule) ([]string, error) {
 	}
 
 	var addedDate []string
+	var flag bool
 
 	for _, s := range schedule {
-		if s.date == "" || len(s.login)	== 0 {
+		if s.Date == "" || len(s.Login)	== 0 {
 			continue
 		}
-		for _, l := range s.login {
+		flag = false
+		for _, l := range s.Login {
 			// loginからUserIDを取得
 			userId, err := getUserIdFromLogin(db, l)
 			if err != nil {
@@ -360,20 +362,23 @@ func addShiftToDB(schedule []Schedule) ([]string, error) {
 			}
 			// s.dateとloginが一致するシフトがすでに存在した場合はスキップ
 			var shift Shift
-			if err := db.Where("user_id = ? AND date = ?", userId, s.date).First(&shift).Error; err != nil {
+			if err := db.Where("user_id = ? AND date = ?", userId, s.Date).First(&shift).Error; err != nil {
 				if err != gorm.ErrRecordNotFound {
 					return nil, err
 				}
 				// s.dateとlogin情報を追加
-				shift = Shift{Date: s.date, UserID: userId}
+				shift = Shift{Date: s.Date, UserID: userId}
 				if result := db.Create(&shift); result.Error != nil {
 					return nil, result.Error
 				}
+				flag = true
 			} else {
 				continue
 			}
 		}
-		addedDate = append(addedDate, s.date)
+		if flag {
+			addedDate = append(addedDate, s.Date)
+		}
 	}
 	return addedDate, nil
 }

--- a/api/src/db.go
+++ b/api/src/db.go
@@ -13,7 +13,7 @@ import (
 type Shift struct {
 	ID	uint   `gorm:"primaryKey"`
 	Date  string
-	UserID uint `json: "user_id"`
+	UserID int `json: "user_id"`
 	User  User `gorm:"foreignKey:UserID"`
 }
 
@@ -55,6 +55,10 @@ type Location struct {
 type Role struct {
 	ID int
 	Name string
+}
+
+type Date struct {
+	Date string
 }
 
 func initializeDB() (*gorm.DB, error) {
@@ -334,4 +338,50 @@ func addUidToExistUser(login string, uid string) bool {
 		panic("database error")
 	}
 	return true
+}
+
+func addShiftToDB(schedule []Schedule) ([]string, error) {
+	db, err := connectToDB()
+	if err != nil {
+		panic("database error")
+	}
+
+	var addedDate []string
+
+	for _, s := range schedule {
+		if s.date == "" || len(s.login)	== 0 {
+			continue
+		}
+		for _, l := range s.login {
+			// loginからUserIDを取得
+			userId, err := getUserIdFromLogin(db, l)
+			if err != nil {
+				return nil, err
+			}
+			// s.dateとloginが一致するシフトがすでに存在した場合はスキップ
+			var shift Shift
+			if err := db.Where("user_id = ? AND date = ?", userId, s.date).First(&shift).Error; err != nil {
+				if err != gorm.ErrRecordNotFound {
+					return nil, err
+				}
+				// s.dateとlogin情報を追加
+				shift = Shift{Date: s.date, UserID: userId}
+				if result := db.Create(&shift); result.Error != nil {
+					return nil, result.Error
+				}
+			} else {
+				continue
+			}
+		}
+		addedDate = append(addedDate, s.date)
+	}
+	return addedDate, nil
+}
+
+func getUserIdFromLogin(db *gorm.DB, login string) (int, error) {
+	var user User
+	if err := db.Where("login = ?", login).First(&user).Error; err != nil {
+		return 0, err
+	}
+	return user.ID, nil
 }

--- a/api/src/main.go
+++ b/api/src/main.go
@@ -56,12 +56,8 @@ type M5StickRequestData struct {
 }
 
 type Schedule struct {
-	date string
-	login []string
-}
-
-type ShiftRequestData struct {
-	Shift []Schedule `json:"shift"`
+	Date string `json:"date"`
+	Login []string `json:"login"`
 }
 
 type UserData struct {
@@ -94,7 +90,7 @@ func main() {
 	router.POST("/receive-uid", HandleUIDSubmission)
 
 	router.GET("/shift", getShiftData)
-	// router.POST("/shift", addShiftData)
+	router.POST("/shift", addShiftData)
 
 	router.POST("/activities", addActivity)
 	router.GET("/activities/cleanings", getCleanData)
@@ -128,17 +124,23 @@ func getShiftData(c *gin.Context) {
 }
 
 func addShiftData(c *gin.Context) {
-	var requestData ShiftRequestData
+	var schedule []Schedule
 
-	if err := c.BindJSON(&requestData); err != nil {
+	if err := c.BindJSON(&schedule); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	if len(requestData.Shift) == 0 {
+	if len(schedule) == 0 {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Shift is required"})
 		return
 	}
-	if date, err := addShiftToDB(requestData.Shift); err != nil {
+	for _, s := range schedule {
+		log.Println(s.Date)
+		for _, l := range s.Login {
+			log.Println(l)
+		}
+	}
+	if date, err := addShiftToDB(schedule); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	} else {

--- a/api/src/main.go
+++ b/api/src/main.go
@@ -55,6 +55,15 @@ type M5StickRequestData struct {
 	LocationName string `json:"location"`
 }
 
+type Schedule struct {
+	date string
+	login []string
+}
+
+type ShiftRequestData struct {
+	Shift []Schedule `json:"shift"`
+}
+
 type UserData struct {
 	IntraName string `json:"intra_name"`
 }
@@ -85,6 +94,7 @@ func main() {
 	router.POST("/receive-uid", HandleUIDSubmission)
 
 	router.GET("/shift", getShiftData)
+	// router.POST("/shift", addShiftData)
 
 	router.POST("/activities", addActivity)
 	router.GET("/activities/cleanings", getCleanData)
@@ -115,6 +125,25 @@ func getShiftData(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, shifts)
+}
+
+func addShiftData(c *gin.Context) {
+	var requestData ShiftRequestData
+
+	if err := c.BindJSON(&requestData); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if len(requestData.Shift) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Shift is required"})
+		return
+	}
+	if date, err := addShiftToDB(requestData.Shift); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	} else {
+		c.JSON(http.StatusOK, gin.H{"date": date})
+	}
 }
 
 func getCleanData(c *gin.Context) {


### PR DESCRIPTION
This PR is to resolve #62 .

- POST /shift エンドポイントの追加
- openapi.ymlの追記
- 下記のようなjsonを受け取り、DBに反映した日付を返す
```json
[{"date": "2024-05-01","login": ["user1", "user2"]},{"date": "2024-05-02","login": ["user3", "user4"]}]
```