### PR TITLE
70 make addusers

### DIFF
--- a/api/openapi/openapi.yml
+++ b/api/openapi/openapi.yml
@@ -73,11 +73,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/responseUserDataArray'
         '400':
-          description: "失敗。エラーメッセージをjsonで返します"
+          description: "失敗。エラーメッセージと追加に成功したuserの配列をjsonで返します"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                type: object
+                properties:
+                  error: {type: string, example: "Error message"}
+                  users: {type: array, example: ["a", "b", "c"]}
     put:
       summary: "ユーザの編集"
       description: "intra名に紐づくuidやwalletアドレスを更新します"
@@ -269,8 +272,7 @@ components:
       properties:
         users: 
           type: array
-          items: 
-            $ref: '#/components/schemas/UserData'
+          example: ["a", "b", "c"]
     addedDate:
       type: object
       properties:

--- a/api/openapi/openapi.yml
+++ b/api/openapi/openapi.yml
@@ -56,22 +56,22 @@ paths:
   /users:
     post:
       summary: "ユーザの追加"
-      description: "intra名とuidやwalletアドレスを追加します"
+      description: "任意人数のlogin, uid, walletをDBに追加します"
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UserData'
+              $ref: '#/components/schemas/importUserData'
               required:
-                - login
+                - users
       responses:
         '200':
-          description: "成功。追加したユーザをjsonで返します"
+          description: "成功。追加したuserの配列をjsonで返します"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UserData'
+                $ref: '#/components/schemas/responseUserDataArray'
         '400':
           description: "失敗。エラーメッセージをjsonで返します"
           content:
@@ -257,6 +257,20 @@ components:
           login: ["user1", "user2"]
         - date: "2024-05-02"
           login: ["user3", "user4"]
+    importUserData:
+      type: object
+      properties:
+        users: 
+          type: array
+          items: 
+            $ref: '#/components/schemas/UserData'
+    responseUserDataArray:
+      type: object
+      properties:
+        users: 
+          type: array
+          items: 
+            $ref: '#/components/schemas/UserData'
     addedDate:
       type: object
       properties:

--- a/cmd/ft_activity_api/main.go
+++ b/cmd/ft_activity_api/main.go
@@ -45,7 +45,7 @@ func main() {
 
 	router.POST("/m5sticks", handlers.AddM5Stick)
 
-	router.POST("/users", handlers.AddUser)
+	router.POST("/users", handlers.AddUsers)
 	router.PUT("/users", handlers.EditUser)
 
 	router.Run(":" + os.Getenv("PORT"))

--- a/internal/accessdb/connect_db.go
+++ b/internal/accessdb/connect_db.go
@@ -59,6 +59,16 @@ type Schedule struct {
 	Login []string `json:"login"`
 }
 
+type UserRequestData struct {
+	Uid    string `json:"uid"`
+	Login  string `json:"login"`
+	Wallet string `json:"wallet"`
+}
+
+type Users struct {
+	Users []UserRequestData `json:"users"`
+}
+
 func ConnectToDB() (*gorm.DB, error) {
 	dsn, err := getDSN()
 	if err != nil {

--- a/internal/accessdb/user_db.go
+++ b/internal/accessdb/user_db.go
@@ -57,3 +57,26 @@ func EditUserInDB(uid string, login string, wallet string) error {
 	}
 	return nil
 }
+
+// Receives uid, login, and wallet, and if the same login does not exist in the DB, adds a new user.
+func AddUserToDB(uid string, login string, wallet string) error {
+	db, err := ConnectToDB()
+	if err != nil {
+		return err
+	}
+
+	var existingUser User
+	if err := db.Where("login = ?", login).First(&existingUser).Error; err != nil {
+		if err != gorm.ErrRecordNotFound {
+			return err
+		}
+	} else {
+		return errors.New("User already exists")
+	}
+	user := User{UID: uid, Login: login, Wallet: wallet}
+
+	if result := db.Create(&user); result.Error != nil {
+		return result.Error
+	}
+	return nil
+}

--- a/internal/accessdb/user_db.go
+++ b/internal/accessdb/user_db.go
@@ -5,7 +5,60 @@ import (
 	"gorm.io/gorm"
 )
 
-// Receives uid, login, and wallet, and if the same login does not exist in the DB, adds a new user.
+func AddUsersToDB(users []UserRequestData) ([]string, error) {
+	db, err := ConnectToDB()
+	if err != nil {
+		return nil, err
+	}
+	var addedLogin []string
+
+	// 配列を順に処理
+	for _, u := range users {
+		// loginがDBに存在するか確認
+		var existingUser User
+		var user User
+		if err := db.Where("login = ?", u.Login).First(&existingUser).Error; err != nil {
+			// DBに存在しない以外のエラーはエラーとして返す
+			if err != gorm.ErrRecordNotFound {
+				return addedLogin, err
+			}
+		} else {
+			// DBに存在する場合
+			if result := db.Model(&existingUser).Updates(User{UID: u.Uid, Wallet: u.Wallet}); result.Error != nil {
+				return addedLogin, result.Error
+			}
+			addedLogin = append(addedLogin, u.Login)
+			continue
+		}
+		// DBに存在しない場合
+		user = User{UID: u.Uid, Login: u.Login, Wallet: u.Wallet}
+		if result := db.Create(&user); result.Error != nil {
+			return addedLogin, result.Error
+		}
+		addedLogin = append(addedLogin, u.Login)
+	}
+	return addedLogin, nil
+}
+
+// Receive uid, login, and wallet, and if the same login exists in the DB, update the user data.
+func EditUserInDB(uid string, login string, wallet string) error {
+	db, err := ConnectToDB()
+	if err != nil {
+		return err
+	}
+
+	var existingUser User
+	if err := db.Where("login = ?", login).First(&existingUser).Error; err != nil {
+		return err
+	}
+
+	if result := db.Model(&existingUser).Updates(User{UID: uid, Wallet: wallet}); result.Error != nil {
+		return result.Error
+	}
+	return nil
+}
+
+// Receives uid, login, and wallet, and if the same login does not exist in the DB, adds a new user.(unused)
 func AddUserToDB(uid string, login string, wallet string) error {
 	db, err := ConnectToDB()
 	if err != nil {
@@ -23,24 +76,6 @@ func AddUserToDB(uid string, login string, wallet string) error {
 	user := User{UID: uid, Login: login, Wallet: wallet}
 
 	if result := db.Create(&user); result.Error != nil {
-		return result.Error
-	}
-	return nil
-}
-
-// Receive uid, login, and wallet, and if the same login exists in the DB, update the user data.
-func EditUserInDB(uid string, login string, wallet string) error {
-	db, err := ConnectToDB()
-	if err != nil {
-		return err
-	}
-
-	var existingUser User
-	if err := db.Where("login = ?", login).First(&existingUser).Error; err != nil {
-		return err
-	}
-
-	if result := db.Model(&existingUser).Updates(User{UID: uid, Wallet: wallet}); result.Error != nil {
 		return result.Error
 	}
 	return nil

--- a/internal/accessdb/user_db.go
+++ b/internal/accessdb/user_db.go
@@ -5,32 +5,32 @@ import (
 	"gorm.io/gorm"
 )
 
+/*
+Receives an array of users and updates the login if it exists in the DB,
+or creates a new one if it doesn't. Returns the array of users reflected in the DB.
+*/
 func AddUsersToDB(users []UserRequestData) ([]string, error) {
+	var addedLogin []string
 	db, err := ConnectToDB()
 	if err != nil {
-		return nil, err
+		return addedLogin, err
 	}
-	var addedLogin []string
-
-	// 配列を順に処理
 	for _, u := range users {
-		// loginがDBに存在するか確認
-		var existingUser User
 		var user User
-		if err := db.Where("login = ?", u.Login).First(&existingUser).Error; err != nil {
-			// DBに存在しない以外のエラーはエラーとして返す
+		if u.Login == "" {
+			continue
+		}
+		if err := db.Where("login = ?", u.Login).First(&user).Error; err != nil {
 			if err != gorm.ErrRecordNotFound {
 				return addedLogin, err
 			}
 		} else {
-			// DBに存在する場合
-			if result := db.Model(&existingUser).Updates(User{UID: u.Uid, Wallet: u.Wallet}); result.Error != nil {
+			if result := db.Model(&user).Updates(User{UID: u.Uid, Wallet: u.Wallet}); result.Error != nil {
 				return addedLogin, result.Error
 			}
 			addedLogin = append(addedLogin, u.Login)
 			continue
 		}
-		// DBに存在しない場合
 		user = User{UID: u.Uid, Login: u.Login, Wallet: u.Wallet}
 		if result := db.Create(&user); result.Error != nil {
 			return addedLogin, result.Error
@@ -53,29 +53,6 @@ func EditUserInDB(uid string, login string, wallet string) error {
 	}
 
 	if result := db.Model(&existingUser).Updates(User{UID: uid, Wallet: wallet}); result.Error != nil {
-		return result.Error
-	}
-	return nil
-}
-
-// Receives uid, login, and wallet, and if the same login does not exist in the DB, adds a new user.(unused)
-func AddUserToDB(uid string, login string, wallet string) error {
-	db, err := ConnectToDB()
-	if err != nil {
-		return err
-	}
-
-	var existingUser User
-	if err := db.Where("login = ?", login).First(&existingUser).Error; err != nil {
-		if err != gorm.ErrRecordNotFound {
-			return err
-		}
-	} else {
-		return errors.New("User already exists")
-	}
-	user := User{UID: uid, Login: login, Wallet: wallet}
-
-	if result := db.Create(&user); result.Error != nil {
 		return result.Error
 	}
 	return nil

--- a/internal/handlers/users.go
+++ b/internal/handlers/users.go
@@ -6,15 +6,30 @@ import (
 	"net/http"
 )
 
-type UserRequestData struct {
-	Uid    string `json:"uid"`
-	Login  string `json:"login"`
-	Wallet string `json:"wallet"`
+// Handle the endpoint to add users.
+func AddUsers(c *gin.Context) {
+	var requestData accessdb.Users
+
+	if err := c.BindJSON(&requestData); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if len(requestData.Users) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "User is not specified"})
+		return
+	}
+	if addedLogin, err := accessdb.AddUsersToDB(requestData.Users); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	} else {
+		c.JSON(http.StatusOK, gin.H{"users": addedLogin})
+	}
+	return
 }
 
-// Handle the endpoint to add a user.
-func AddUser(c *gin.Context) {
-	var requestData UserRequestData
+// Handle the endpoint that updates the user.
+func EditUser(c *gin.Context) {
+	var requestData accessdb.UserRequestData
 
 	if err := c.BindJSON(&requestData); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -24,11 +39,7 @@ func AddUser(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Login is required"})
 		return
 	}
-	if accessdb.UserExists(requestData.Login) {
-		c.JSON(http.StatusConflict, gin.H{"error": "User with this login already exists"})
-		return
-	}
-	if err := accessdb.AddUserToDB(requestData.Uid, requestData.Login, requestData.Wallet); err != nil {
+	if err := accessdb.EditUserInDB(requestData.Uid, requestData.Login, requestData.Wallet); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
@@ -46,9 +57,9 @@ func AddUser(c *gin.Context) {
 	return
 }
 
-// Handle the endpoint that updates the user.
-func EditUser(c *gin.Context) {
-	var requestData UserRequestData
+// Handle the endpoint to add a user.(unused)
+func AddUser(c *gin.Context) {
+	var requestData accessdb.UserRequestData
 
 	if err := c.BindJSON(&requestData); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -58,7 +69,11 @@ func EditUser(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Login is required"})
 		return
 	}
-	if err := accessdb.EditUserInDB(requestData.Uid, requestData.Login, requestData.Wallet); err != nil {
+	if accessdb.UserExists(requestData.Login) {
+		c.JSON(http.StatusConflict, gin.H{"error": "User with this login already exists"})
+		return
+	}
+	if err := accessdb.AddUserToDB(requestData.Uid, requestData.Login, requestData.Wallet); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}

--- a/internal/handlers/users.go
+++ b/internal/handlers/users.go
@@ -19,7 +19,7 @@ func AddUsers(c *gin.Context) {
 		return
 	}
 	if addedLogin, err := accessdb.AddUsersToDB(requestData.Users); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "users": addedLogin})
 		return
 	} else {
 		c.JSON(http.StatusOK, gin.H{"users": addedLogin})
@@ -40,40 +40,6 @@ func EditUser(c *gin.Context) {
 		return
 	}
 	if err := accessdb.EditUserInDB(requestData.Uid, requestData.Login, requestData.Wallet); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-	response := make(gin.H)
-
-	response["login"] = requestData.Login
-	if requestData.Uid != "" {
-		response["uid"] = requestData.Uid
-	}
-	if requestData.Wallet != "" {
-		response["wallet"] = requestData.Wallet
-	}
-
-	c.JSON(http.StatusOK, response)
-	return
-}
-
-// Handle the endpoint to add a user.(unused)
-func AddUser(c *gin.Context) {
-	var requestData accessdb.UserRequestData
-
-	if err := c.BindJSON(&requestData); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-	if requestData.Login == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Login is required"})
-		return
-	}
-	if accessdb.UserExists(requestData.Login) {
-		c.JSON(http.StatusConflict, gin.H{"error": "User with this login already exists"})
-		return
-	}
-	if err := accessdb.AddUserToDB(requestData.Uid, requestData.Login, requestData.Wallet); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}


### PR DESCRIPTION
This PR is to resolve #70.

## POST /usersの改修

- user1人のみを追加するのではなく、配列で複数userを追加できるように変更した。
- userがすでに存在する場合はuserの更新を行い、userが存在しない場合は追加するようにした。
- エラーが発生した場合、エラーに加えてエラー発生までにDBに反映したuserを返すようにした。
```
// エラー時に返却されるjson
{
  "error": "Error message",
  "users": [
    "a",
    "b",
    "c"
  ]
}
```
- 正常に終了した場合、反映したuserの配列を返すようにした。
```
{
  "users": [
    "a",
    "b",
    "c"
  ]
}
```
- loginが""のuserが存在した場合は、エラーにならず処理が継続される。