### PR TITLE
75 add an endpoint to delete shift

### DIFF
--- a/api/openapi/openapi.yml
+++ b/api/openapi/openapi.yml
@@ -381,6 +381,7 @@ components:
         UserID: {type: integer, example: 1}
         User:
           $ref: '#/components/schemas/User'
+        DeletedAt: {type: string, example: "2024-06-19T11:55:03.892Z"}
     M5Stick:
       type: object
       properties:

--- a/api/openapi/openapi.yml
+++ b/api/openapi/openapi.yml
@@ -53,6 +53,31 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+    delete:
+      summary: "シフトの削除"
+      description: "特定の日付とそれに対応したloginのシフトを論理削除します。"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/deleteShiftsRequestBody'
+              required:
+                - login
+                - date
+      responses:
+        '200':
+          description: "成功。削除したシフトをjsonで返します"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Shift'
+        '400':
+          description: "失敗。エラーメッセージをjsonで返します"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /shifts/exchange:
     post:
       summary: "シフトの交換"
@@ -301,6 +326,15 @@ components:
           type: string
           example: "YYYY-MM-DD"
         date2:
+          type: string
+          example: "YYYY-MM-DD"
+    deleteShiftsRequestBody:
+      type: object
+      properties:
+        login:
+          type: string
+          example: "foo"
+        date:
           type: string
           example: "YYYY-MM-DD"
     usersArray:

--- a/cmd/ft_activity_api/main.go
+++ b/cmd/ft_activity_api/main.go
@@ -36,6 +36,7 @@ func main() {
 	router.GET("/shifts", handlers.GetShiftData)
 	router.POST("/shifts", handlers.AddShiftData)
 	router.POST("/shifts/exchange", handlers.ExchangeShiftData)
+	router.DELETE("/shifts", handlers.DeleteShiftData)
 
 	router.POST("/activities", handlers.AddActivity)
 	router.GET("/activities/cleanings", handlers.GetActivityCleanData)

--- a/internal/accessdb/connect_db.go
+++ b/internal/accessdb/connect_db.go
@@ -13,6 +13,7 @@ type Shift struct {
 	Date   string
 	UserID int  `json: "user_id"`
 	User   User `gorm:"foreignKey:UserID"`
+	DeletedAt gorm.DeletedAt
 }
 
 type User struct {

--- a/internal/handlers/shifts.go
+++ b/internal/handlers/shifts.go
@@ -16,6 +16,11 @@ type ExchangeData struct {
 	Date2  string `json:"date2"`
 }
 
+type DeleteData struct {
+	Login string `json:"login"`
+	Date  string `json:"date"`
+}
+
 // Handle the endpoint that gets the shift.
 func GetShiftData(c *gin.Context) {
 	date, err := getQueryAboutDate(c)
@@ -90,5 +95,28 @@ func ExchangeShiftData(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
 			"shifts": []*accessdb.Shift{shift1, shift2},
 		})
+	}
+}
+
+// Handle the endpoint that deletes a shift.
+func DeleteShiftData(c *gin.Context) {
+	var d DeleteData
+	if err := c.BindJSON(&d); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if d.Login == "" || d.Date == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "login and date are required"})
+		return
+	}
+	if !isDateStringValid(d.Date) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid date format. It should be in YYYY/MM/DD format"})
+		return
+	}
+	if shift, err := accessdb.DeleteShiftFromDB(d.Login, d.Date); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	} else {
+		c.JSON(http.StatusOK, shift)
 	}
 }


### PR DESCRIPTION
This PR is to resolve #75 .

- 特定の日付のloginのシフトを論理削除するエンドポイントの追加
- ShiftテーブルのカラムにDeletedAtを追加
- openapiの追記
- シフト交換・削除におけるトランザクション分離レベルをSerializableにした