### PR TITLE
Minor fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     ports:
       - "${API_PORT}:${API_PORT}"
     networks:
+      - activityapi-network
       - docker-network
     environment:
       DSN: ${DSN}
@@ -29,7 +30,7 @@ services:
     ports:
       - "3306:${MARIA_PORT}"
     networks:
-      - docker-network
+      - activityapi-network
     environment:
       MARIADB_ROOT_PASSWORD: ${MARIA_ROOT_PASS}
       MARIADB_DATABASE: ${MARIA_NAME}
@@ -47,12 +48,14 @@ services:
     ports:
       - 8080:8080
     networks:
-      - docker-network
+      - activityapi-network
     depends_on:
       mariadb:
         condition: service_healthy
 volumes:
   mariadb:
 networks:
-  docker-network:
+  activityapi-network:
     driver: bridge
+  docker-network:
+    external: true

--- a/internal/handlers/shifts.go
+++ b/internal/handlers/shifts.go
@@ -45,7 +45,7 @@ func AddShiftData(c *gin.Context) {
 		return
 	}
 	if date, err := accessdb.AddShiftToDB(schedule); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	} else {
 		c.JSON(http.StatusOK, gin.H{"date": date})
@@ -84,7 +84,7 @@ func ExchangeShiftData(c *gin.Context) {
 		return
 	}
 	if shift1, shift2, err := accessdb.ExchangeShiftsOnDB(e.Login1, e.Login2, e.Date1, e.Date2); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	} else {
 		c.JSON(http.StatusOK, gin.H{

--- a/internal/handlers/shifts.go
+++ b/internal/handlers/shifts.go
@@ -80,7 +80,7 @@ func ExchangeShiftData(c *gin.Context) {
 		return
 	}
 	if !isDateStringValid(e.Date1) || !isDateStringValid(e.Date2) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid date format. It should be in YYYY/MM/DD format"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid date format. It should be in YYYY-MM-DD format"})
 		return
 	}
 	if shift1, shift2, err := accessdb.ExchangeShiftsOnDB(e.Login1, e.Login2, e.Date1, e.Date2); err != nil {


### PR DESCRIPTION
This PR is to resolve #78 .

- discordbotのコンテナとの通信を行うため、docker-networkについてexternal:trueにし、activityapi-networkをbridgeにした。
- /shifts/exchangeのdateは2024-05-01のようなフォーマットで受け取るようになっているが、エラーメッセージが「2024/05/01にすべき」だったため、正しい表記へ修正した。
- /shiftsについて、エラー時のhttpステータスコードを一部400ではなく500にした。